### PR TITLE
Allow overriding PU_TX and PU_RX

### DIFF
--- a/src/pu_config.h
+++ b/src/pu_config.h
@@ -5,8 +5,12 @@
 #endif
 
 // port and bit for Tx and Rx - can be same
+#ifndef PU_TX
 #define PU_TX B,0
+#endif
+#ifndef PU_RX
 #define PU_RX B,1
+#endif
 
 // disable interrupts during Tx and Rx
 #define PU_DISABLE_IRQ 1


### PR DESCRIPTION
Just like PU_BAUD_RATE can be defined externally through a simple #define.

Fixes #8.